### PR TITLE
Only run CI when pushing to master

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,6 +1,10 @@
 name: Rust
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
It's still being run for all pull requests, but with the previous
configuration, it also ran when I pushed to a branch I made for a pull
request. This resulted in two builds per pull request.