### PR TITLE
Share one target directory between all projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Cargo
 */Cargo.lock
-*/target
+/target
 
 # OpenOCD
 */openocd.log

--- a/firmware-lib/.cargo/config
+++ b/firmware-lib/.cargo/config
@@ -1,0 +1,2 @@
+[build]
+target-dir = "../target"

--- a/host-lib/.cargo/config
+++ b/host-lib/.cargo/config
@@ -1,0 +1,2 @@
+[build]
+target-dir = "../target"

--- a/messages/.cargo/config
+++ b/messages/.cargo/config
@@ -1,0 +1,2 @@
+[build]
+target-dir = "../target"

--- a/test-suite/.cargo/config
+++ b/test-suite/.cargo/config
@@ -1,0 +1,2 @@
+[build]
+target-dir = "../target"

--- a/test-target/.cargo/config
+++ b/test-target/.cargo/config
@@ -1,5 +1,6 @@
 [build]
 target = "thumbv6m-none-eabi"
+target-dir = "../target"
 
 [target.thumbv6m-none-eabi]
 runner = "arm-none-eabi-gdb -tui -q -x openocd.gdb"


### PR DESCRIPTION
I have at several points attempted to add everything here to a single
workspace, but this didn't work out. Workspaces generally assume some
uniformity, but the firmware- and host-specific crates are a bit too
different in this regard.

This commit adds configuration to all crates that defines a single,
shared target directory, which is one of the features that a workspace
provides. This should reduce the time required for a clean build, which
is especially relevent for CI.