### PR TITLE
Add `TestStand` struct to host-lib

### DIFF
--- a/host-lib/src/lib.rs
+++ b/host-lib/src/lib.rs
@@ -5,6 +5,7 @@ pub mod config;
 pub mod error;
 pub mod serial;
 pub mod target;
+pub mod test_stand;
 
 
 pub use self::{
@@ -14,4 +15,5 @@ pub use self::{
     },
     serial::Serial,
     target::Target,
+    test_stand::TestStand,
 };

--- a/host-lib/src/lib.rs
+++ b/host-lib/src/lib.rs
@@ -9,6 +9,7 @@ pub mod test_stand;
 
 
 pub use self::{
+    config::Config,
     error::{
         Error,
         Result,

--- a/host-lib/src/target.rs
+++ b/host-lib/src/target.rs
@@ -1,14 +1,8 @@
 use std::{
     slice,
-    sync::{
-        LockResult,
-        Mutex,
-        MutexGuard,
-    },
     time::Duration,
 };
 
-use lazy_static::lazy_static;
 use serde::{
     Deserialize,
     Serialize,
@@ -24,31 +18,12 @@ use crate::Error;
 
 /// The test suite's connection to the test target (device under test)
 pub struct Target {
-    port:   Box<dyn SerialPort>,
-    _guard: LockResult<MutexGuard<'static, ()>>,
+    port: Box<dyn SerialPort>,
 }
 
 impl Target {
     /// Open a connection to the target
     pub fn new(path: &str) -> Result<Self, TargetInitError> {
-        // By default, Rust runs tests in parallel on multiple threads. This can
-        // be controlled through a command-line argument and an environment
-        // variable, but there doesn't seem to be a way to configure this in
-        // `Cargo.toml` or a configuration file.
-        //
-        // Let's just use a mutex here to prevent our tests from running in
-        // parallel. The returned guard will be stored as a field, meaning the
-        // mutex will be held until this struct is dropped. Concurrent
-        // instantiations of this method will block here, until the `Target`
-        // instance holding the mutex has been dropped.
-        //
-        // Please note that this returns a `Result` that we don't unwrap. Doing
-        // so is not necessary, as the error case just tells us that another
-        // thread holding this lock panicked. We don't care about that, as the
-        // mutex is still acquired in that case.
-        lazy_static! { static ref MUTEX: Mutex<()> = Mutex::new(()); }
-        let guard = MUTEX.lock();
-
         let port =
             serialport::open_with_settings(
                 path,
@@ -68,7 +43,6 @@ impl Target {
         Ok(
             Self {
                 port,
-                _guard: guard,
             }
         )
     }

--- a/host-lib/src/test_stand.rs
+++ b/host-lib/src/test_stand.rs
@@ -1,0 +1,42 @@
+use std::sync::{
+    LockResult,
+    Mutex,
+    MutexGuard,
+};
+
+use lazy_static::lazy_static;
+
+
+/// An instance of the test stand
+///
+/// Holds all the resources that a test case might require.
+pub struct TestStand {
+    _guard: LockResult<MutexGuard<'static, ()>>,
+}
+
+impl TestStand {
+    /// Create a new instance of `TestStand`
+    pub fn new() -> Self {
+        // By default, Rust runs tests in parallel on multiple threads. This can
+        // be controlled through a command-line argument and an environment
+        // variable, but there doesn't seem to be a way to configure this in
+        // `Cargo.toml` or a configuration file.
+        //
+        // Let's just use a mutex here to prevent our tests from running in
+        // parallel. The returned guard will be stored as a field, meaning the
+        // mutex will be held until this struct is dropped. Concurrent
+        // instantiations of this method will block here, until the `TestStand`
+        // instance holding the mutex has been dropped.
+        //
+        // Please note that this returns a `Result` that we don't unwrap. Doing
+        // so is not necessary, as the error case just tells us that another
+        // thread holding this lock panicked. We don't care about that, as the
+        // mutex is still acquired in that case.
+        lazy_static! { static ref MUTEX: Mutex<()> = Mutex::new(()); }
+        let guard = MUTEX.lock();
+
+        Self {
+            _guard: guard,
+        }
+    }
+}

--- a/test-suite/src/error.rs
+++ b/test-suite/src/error.rs
@@ -1,6 +1,9 @@
-use host_lib::serial::{
-    SerialSendError,
-    SerialWaitError,
+use host_lib::{
+    serial::{
+        SerialSendError,
+        SerialWaitError,
+    },
+    test_stand::TestStandInitError,
 };
 
 use super::{
@@ -8,7 +11,6 @@ use super::{
         TargetUsartSendError,
         TargetUsartWaitError,
     },
-    test_stand::TestStandInitError,
 };
 
 

--- a/test-suite/src/target.rs
+++ b/test-suite/src/target.rs
@@ -9,20 +9,17 @@ use lpc845_messages::{
 };
 
 use host_lib::target::{
-    TargetInitError,
     TargetReceiveError,
     TargetSendError,
 };
 
 
 /// Test-suite-specific wrapper around `host_lib::Target`
-pub struct Target(host_lib::Target);
+pub struct Target<'r>(&'r mut host_lib::Target);
 
-impl Target {
-    /// Open a connection to the target
-    pub fn new(path: &str) -> Result<Self, TargetInitError> {
-        let target = host_lib::Target::new(path)?;
-        Ok(Self(target))
+impl<'r> Target<'r> {
+    pub(crate) fn new(target: &'r mut host_lib::Target) -> Self {
+        Self(target)
     }
 
     /// Instruct the target to send this message via USART

--- a/test-suite/src/test_stand.rs
+++ b/test-suite/src/test_stand.rs
@@ -1,13 +1,6 @@
 use host_lib::{
-    config::{
-        Config,
-        ConfigReadError,
-    },
-    serial::{
-        Serial,
-        SerialInitError,
-    },
-    target::TargetInitError,
+    serial::Serial,
+    test_stand::TestStandInitError,
 };
 
 use super::target::Target;
@@ -17,10 +10,7 @@ use super::target::Target;
 ///
 /// Used to access all resources that a test case requires.
 pub struct TestStand {
-    _test_stand: host_lib::TestStand,
-
-    target: host_lib::Target,
-    serial: Serial,
+    test_stand: host_lib::TestStand,
 }
 
 impl TestStand {
@@ -29,41 +19,22 @@ impl TestStand {
     /// Reads the `test-stand.toml` configuration file and initializes test
     /// stand resources, as configured in there.
     pub fn new() -> Result<Self, TestStandInitError> {
-        let test_stand = host_lib::TestStand::new();
-
-        let config = Config::read()
-            .map_err(|err| TestStandInitError::ConfigRead(err))?;
-
-        let target = host_lib::Target::new(&config.target)
-            .map_err(|err| TestStandInitError::TargetInit(err))?;
-        let serial = Serial::new(&config.serial)
-            .map_err(|err| TestStandInitError::SerialInit(err))?;
+        let test_stand = host_lib::TestStand::new()?;
 
         Ok(
             TestStand {
-                _test_stand: test_stand,
-
-                target,
-                serial,
+                test_stand,
             }
         )
     }
 
     /// Returns the connection to the test target (device under test)
     pub fn target(&mut self) -> Target {
-        Target::new(&mut self.target)
+        Target::new(&mut self.test_stand.target)
     }
 
     /// Returns the connection to the Serial-to-USB converter
     pub fn serial(&mut self) -> &mut Serial {
-        &mut self.serial
+        &mut self.test_stand.serial
     }
-}
-
-
-#[derive(Debug)]
-pub enum TestStandInitError {
-    ConfigRead(ConfigReadError),
-    SerialInit(SerialInitError),
-    TargetInit(TargetInitError),
 }

--- a/test-suite/src/test_stand.rs
+++ b/test-suite/src/test_stand.rs
@@ -19,7 +19,7 @@ use super::target::Target;
 pub struct TestStand {
     _test_stand: host_lib::TestStand,
 
-    target: Target,
+    target: host_lib::Target,
     serial: Serial,
 }
 
@@ -34,7 +34,7 @@ impl TestStand {
         let config = Config::read()
             .map_err(|err| TestStandInitError::ConfigRead(err))?;
 
-        let target = Target::new(&config.target)
+        let target = host_lib::Target::new(&config.target)
             .map_err(|err| TestStandInitError::TargetInit(err))?;
         let serial = Serial::new(&config.serial)
             .map_err(|err| TestStandInitError::SerialInit(err))?;
@@ -50,8 +50,8 @@ impl TestStand {
     }
 
     /// Returns the connection to the test target (device under test)
-    pub fn target(&mut self) -> &mut Target {
-        &mut self.target
+    pub fn target(&mut self) -> Target {
+        Target::new(&mut self.target)
     }
 
     /// Returns the connection to the Serial-to-USB converter

--- a/test-suite/src/test_stand.rs
+++ b/test-suite/src/test_stand.rs
@@ -9,9 +9,7 @@ use super::target::Target;
 /// An instance of the test stand
 ///
 /// Used to access all resources that a test case requires.
-pub struct TestStand {
-    test_stand: host_lib::TestStand,
-}
+pub struct TestStand(host_lib::TestStand);
 
 impl TestStand {
     /// Initializes the test stand
@@ -20,21 +18,16 @@ impl TestStand {
     /// stand resources, as configured in there.
     pub fn new() -> Result<Self, TestStandInitError> {
         let test_stand = host_lib::TestStand::new()?;
-
-        Ok(
-            TestStand {
-                test_stand,
-            }
-        )
+        Ok(TestStand(test_stand))
     }
 
     /// Returns the connection to the test target (device under test)
     pub fn target(&mut self) -> Target {
-        Target::new(&mut self.test_stand.target)
+        Target::new(&mut self.0.target)
     }
 
     /// Returns the connection to the Serial-to-USB converter
     pub fn serial(&mut self) -> &mut Serial {
-        &mut self.test_stand.serial
+        &mut self.0.serial
     }
 }

--- a/test-suite/src/test_stand.rs
+++ b/test-suite/src/test_stand.rs
@@ -17,6 +17,8 @@ use super::target::Target;
 ///
 /// Used to access all resources that a test case requires.
 pub struct TestStand {
+    _test_stand: host_lib::TestStand,
+
     target: Target,
     serial: Serial,
 }
@@ -27,6 +29,8 @@ impl TestStand {
     /// Reads the `test-stand.toml` configuration file and initializes test
     /// stand resources, as configured in there.
     pub fn new() -> Result<Self, TestStandInitError> {
+        let test_stand = host_lib::TestStand::new();
+
         let config = Config::read()
             .map_err(|err| TestStandInitError::ConfigRead(err))?;
 
@@ -37,6 +41,8 @@ impl TestStand {
 
         Ok(
             TestStand {
+                _test_stand: test_stand,
+
                 target,
                 serial,
             }


### PR DESCRIPTION
This moves more code that is not specific to the test suite into host-lib.