### PR TITLE
Fix target going to sleep a bit too eagerly

### DIFF
--- a/test-target/src/main.rs
+++ b/test-target/src/main.rs
@@ -241,7 +241,7 @@ const APP: () = {
             // us up before the test suite times out. But it could also lead to
             // spurious test failures.
             interrupt::free(|_| {
-                if !receiver.can_receive() {
+                if !receiver.can_receive() && !usart_queue.ready() {
                     asm::wfi();
                 }
             });


### PR DESCRIPTION
It went to sleep when no data could be received from USART0, but didn't
consider USART1. With this commit, it considers both.

Close #20