### PR TITLE
Disable GDB text ui in runner config

### DIFF
--- a/test-target/.cargo/config
+++ b/test-target/.cargo/config
@@ -3,7 +3,7 @@ target = "thumbv6m-none-eabi"
 target-dir = "../target"
 
 [target.thumbv6m-none-eabi]
-runner = "arm-none-eabi-gdb -tui -q -x openocd.gdb"
+runner = "arm-none-eabi-gdb -q -x openocd.gdb"
 rustflags = [
     "-C", "link-arg=-Tlink.x",
 ]


### PR DESCRIPTION
This used to work perfectly, but a recent GDB version introduced a bug:
If the code the MCU is currently executing can't be displayed (as is the
case for core library code, for example), then GDB will print and error
and refuse to proceed. Previously, it would just print something like
"code not available", where the code would otherwise go.

It's kind of a shame to lose this, as it's very useful for debugging,
but the error is far too annoying in practice. The `-tui` option can be
added selectively, if required.