### PR TITLE
Use assistant boards for USART tests instead of USB/serial converter

### DIFF
--- a/host-lib/src/config.rs
+++ b/host-lib/src/config.rs
@@ -10,8 +10,8 @@ use crate::Error;
 
 #[derive(Deserialize)]
 pub struct Config {
-    pub target: String,
-    pub serial: String,
+    pub target: Option<String>,
+    pub serial: Option<String>,
 }
 
 impl Config {

--- a/host-lib/src/config.rs
+++ b/host-lib/src/config.rs
@@ -10,8 +10,9 @@ use crate::Error;
 
 #[derive(Deserialize)]
 pub struct Config {
-    pub target: Option<String>,
-    pub serial: Option<String>,
+    pub target:    Option<String>,
+    pub assistant: Option<String>,
+    pub serial:    Option<String>,
 }
 
 impl Config {

--- a/host-lib/src/test_stand.rs
+++ b/host-lib/src/test_stand.rs
@@ -28,8 +28,9 @@ use crate::{
 pub struct TestStand {
     _guard: LockResult<MutexGuard<'static, ()>>,
 
-    pub target: Option<Conn>,
-    pub serial: Option<Serial>,
+    pub target:    Option<Conn>,
+    pub assistant: Option<Conn>,
+    pub serial:    Option<Serial>,
 }
 
 impl TestStand {
@@ -56,11 +57,18 @@ impl TestStand {
         let config = Config::read()
             .map_err(|err| TestStandInitError::ConfigRead(err))?;
 
-        let mut target = None;
-        let mut serial = None;
+        let mut target    = None;
+        let mut assistant = None;
+        let mut serial    = None;
 
         if let Some(path) = config.target {
             target = Some(
+                Conn::new(&path)
+                    .map_err(|err| TestStandInitError::ConnInit(err))?
+            );
+        }
+        if let Some(path) = config.assistant {
+            assistant = Some(
                 Conn::new(&path)
                     .map_err(|err| TestStandInitError::ConnInit(err))?
             );
@@ -77,6 +85,7 @@ impl TestStand {
                 _guard: guard,
 
                 target,
+                assistant,
                 serial,
             },
         )

--- a/host-lib/src/test_stand.rs
+++ b/host-lib/src/test_stand.rs
@@ -28,8 +28,8 @@ use crate::{
 pub struct TestStand {
     _guard: LockResult<MutexGuard<'static, ()>>,
 
-    pub target: Conn,
-    pub serial: Serial,
+    pub target: Option<Conn>,
+    pub serial: Option<Serial>,
 }
 
 impl TestStand {
@@ -56,10 +56,21 @@ impl TestStand {
         let config = Config::read()
             .map_err(|err| TestStandInitError::ConfigRead(err))?;
 
-        let target = Conn::new(&config.target)
-            .map_err(|err| TestStandInitError::ConnInit(err))?;
-        let serial = Serial::new(&config.serial)
-            .map_err(|err| TestStandInitError::SerialInit(err))?;
+        let mut target = None;
+        let mut serial = None;
+
+        if let Some(path) = config.target {
+            target = Some(
+                Conn::new(&path)
+                    .map_err(|err| TestStandInitError::ConnInit(err))?
+            );
+        }
+        if let Some(path) = config.serial {
+            serial = Some(
+                Serial::new(&path)
+                    .map_err(|err| TestStandInitError::SerialInit(err))?
+            );
+        }
 
         Ok(
             Self {

--- a/messages/src/lib.rs
+++ b/messages/src/lib.rs
@@ -14,10 +14,24 @@ pub enum HostToTarget<'r> {
     SendUsart(&'r [u8]),
 }
 
-
 /// An message from the target to the test suite on the host
 #[derive(Deserialize, Serialize)]
 pub enum TargetToHost<'r> {
     /// Notify the host that data has been received via USART
+    UsartReceive(&'r [u8]),
+}
+
+
+/// A message from the test suite on the host to the test assistant
+#[derive(Deserialize, Serialize)]
+pub enum HostToAssistant<'r> {
+    /// Instruct the assistant to send data to the target via USART
+    SendUsart(&'r [u8]),
+}
+
+/// A message from the test assistant to the test suite on the host
+#[derive(Deserialize, Serialize)]
+pub enum AssistantToHost<'r> {
+    /// Notify the host that data has been received from the target via USART
     UsartReceive(&'r [u8]),
 }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -17,5 +17,8 @@ export RUSTFLAGS="-D warnings"
     cd test-target
     cargo build --verbose)
 (
+    cd test-assistant
+    cargo build --verbose)
+(
     cd test-suite
     cargo build --tests --verbose)

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -14,5 +14,8 @@ set -e
     cd test-target
     cargo update)
 (
+    cd test-assistant
+    cargo update)
+(
     cd test-suite
     cargo update)

--- a/test-assistant/.cargo/config
+++ b/test-assistant/.cargo/config
@@ -1,0 +1,9 @@
+[build]
+target = "thumbv6m-none-eabi"
+target-dir = "../target"
+
+[target.thumbv6m-none-eabi]
+runner = "arm-none-eabi-gdb -q -x openocd.gdb"
+rustflags = [
+    "-C", "link-arg=-Tlink.x",
+]

--- a/test-assistant/Cargo.toml
+++ b/test-assistant/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name    = "lpc845-test-assistant"
+version = "0.1.0"
+authors = ["Hanno Braun <hanno@braun-embedded.com>"]
+edition = "2018"
+
+
+[dependencies]
+cortex-m-rtfm     = "0.5.1"
+heapless          = "0.5.3"
+panic-semihosting = "0.5.3"
+
+[dependencies.lpc845-messages]
+version  = "0.1.0"
+path     = "../messages"
+
+[dependencies.firmware-lib]
+version  = "0.1.0"
+path     = "../firmware-lib"
+
+[dependencies.lpc8xx-hal]
+git      = "https://github.com/lpc-rs/lpc8xx-hal.git"
+features = ["845m301jbd48", "845-rt"]
+
+[dependencies.void]
+version          = "1.0.2"
+default-features = false
+
+
+# Without any optimization, the test firmware can't quite keep up with the
+# USART. Let's do some optimization in dev mode, so this works when executed
+# with `cargo run`.
+[profile.dev]
+opt-level = "s"

--- a/test-assistant/dap-serial.cfg
+++ b/test-assistant/dap-serial.cfg
@@ -17,4 +17,4 @@
 # different USB VID/PID, you can also use the `cmsis_dap_vid_pid` directive to
 # specify which one you want to use.
 
-cmsis_dap_serial 11020031
+cmsis_dap_serial 0F01D03A

--- a/test-assistant/openocd.cfg
+++ b/test-assistant/openocd.cfg
@@ -1,0 +1,19 @@
+interface cmsis-dap
+source dap-serial.cfg
+
+transport select swd
+set WORKAREASIZE 8096
+
+source [find target/lpc84x.cfg]
+
+adapter_khz 1000
+
+gdb_port pipe
+log_output openocd.log
+
+tcl_port disabled
+telnet_port disabled
+
+init
+arm semihosting enable
+reset

--- a/test-assistant/openocd.gdb
+++ b/test-assistant/openocd.gdb
@@ -1,0 +1,6 @@
+target remote | openocd
+load
+# Required to work around a weird OpenOCD error message when uploading to the
+# LPC845-BRK.
+monitor reset
+continue

--- a/test-assistant/src/main.rs
+++ b/test-assistant/src/main.rs
@@ -1,0 +1,205 @@
+//! Test assistant firmware
+//!
+//! Used to assist the test suite in interfacing with the test target. Needs to
+//! be downloaded to an LPC845-BRK board before the test cases can be run.
+
+
+#![no_main]
+#![no_std]
+
+
+// Includes a panic handler that outputs panic messages via semihosting. These
+// should show up in OpenOCD.
+extern crate panic_semihosting;
+
+
+use lpc8xx_hal::{
+    Peripherals,
+    cortex_m::{
+        asm,
+        interrupt,
+    },
+    pac::{
+        USART0,
+        USART1,
+    },
+    syscon::frg,
+    usart,
+};
+
+use firmware_lib::usart::{
+    RxIdle,
+    RxInt,
+    Tx,
+    Usart,
+};
+use lpc845_messages::{
+    AssistantToHost,
+    HostToAssistant,
+};
+
+
+#[rtfm::app(device = lpc8xx_hal::pac)]
+const APP: () = {
+    struct Resources {
+        host_rx_int:  RxInt<'static, USART0>,
+        host_rx_idle: RxIdle<'static>,
+        host_tx:      Tx<USART0>,
+
+        target_rx_int:  RxInt<'static, USART1>,
+        target_rx_idle: RxIdle<'static>,
+        target_tx:      Tx<USART1>,
+    }
+
+    #[init]
+    fn init(_: init::Context) -> init::LateResources {
+        // Normally, access to a `static mut` would be unsafe, but we know that
+        // this method is only called once, which means we have exclusive access
+        // here. RTFM knows this too, and by putting these statics right here,
+        // at the beginning of the method, we're opting into some RTFM magic
+        // that gives us safe access to them.
+        static mut HOST:   Usart = Usart::new();
+        static mut TARGET: Usart = Usart::new();
+
+        // Get access to the device's peripherals. This can't panic, since this
+        // is the only place in this program where we call this method.
+        let p = Peripherals::take().unwrap_or_else(|| unreachable!());
+
+        let mut syscon = p.SYSCON.split();
+        let     swm    = p.SWM.split();
+
+        let mut swm_handle = swm.handle.enable(&mut syscon.handle);
+
+        // Configure the clock for USART0, using the Fractional Rate Generator
+        // (FRG) and the USART's own baud rate divider value (BRG). See user
+        // manual, section 17.7.1.
+        //
+        // This assumes a system clock of 12 MHz (which is the default and, as
+        // of this writing, has not been changed in this program). The resulting
+        // rate is roughly 115200 baud.
+        let clock_config = {
+            syscon.frg0.select_clock(frg::Clock::FRO);
+            syscon.frg0.set_mult(22);
+            syscon.frg0.set_div(0xFF);
+            usart::Clock::new(&syscon.frg0, 5, 16)
+        };
+
+        // Assign pins to USART0 for RX/TX functions. On the LPC845-BRK, those
+        // are the pins connected to the programmer, and bridged to the host via
+        // USB.
+        //
+        // Careful, the LCP845-BRK documentation uses the opposite designations
+        // (i.e. from the perspective of the on-board programmer, not the
+        // microcontroller).
+        let (u0_rxd, _) = swm.movable_functions.u0_rxd.assign(
+            p.pins.pio0_24.into_swm_pin(),
+            &mut swm_handle,
+        );
+        let (u0_txd, _) = swm.movable_functions.u0_txd.assign(
+            p.pins.pio0_25.into_swm_pin(),
+            &mut swm_handle,
+        );
+
+        // Use USART0 to communicate with the test suite
+        let mut host = p.USART0.enable(
+            &clock_config,
+            &mut syscon.handle,
+            u0_rxd,
+            u0_txd,
+        );
+        host.enable_rxrdy();
+
+        // Assign pins to USART1.
+        let (u1_rxd, _) = swm.movable_functions.u1_rxd.assign(
+            p.pins.pio0_26.into_swm_pin(),
+            &mut swm_handle,
+        );
+        let (u1_txd, _) = swm.movable_functions.u1_txd.assign(
+            p.pins.pio0_27.into_swm_pin(),
+            &mut swm_handle,
+        );
+
+        // Use USART1 to communicate with the test target
+        let mut target = p.USART1.enable(
+            &clock_config,
+            &mut syscon.handle,
+            u1_rxd,
+            u1_txd,
+        );
+        target.enable_rxrdy();
+
+        let (host_rx_int,   host_rx_idle,   host_tx)   = HOST.init(host);
+        let (target_rx_int, target_rx_idle, target_tx) = TARGET.init(target);
+
+        init::LateResources {
+            host_rx_int,
+            host_rx_idle,
+            host_tx,
+
+            target_rx_int,
+            target_rx_idle,
+            target_tx,
+        }
+    }
+
+    #[idle(resources = [host_rx_idle, host_tx, target_rx_idle, target_tx])]
+    fn idle(cx: idle::Context) -> ! {
+        let host_rx   = cx.resources.host_rx_idle;
+        let host_tx   = cx.resources.host_tx;
+        let target_rx = cx.resources.target_rx_idle;
+        let target_tx = cx.resources.target_tx;
+
+        let mut buf = [0; 256];
+
+        loop {
+            target_rx
+                .process_raw(|data| {
+                    host_tx.send_message(
+                        &AssistantToHost::UsartReceive(data),
+                        &mut buf,
+                    )
+                })
+                .expect("Error processing USART data");
+
+            host_rx
+                .process_message(|message| {
+                    match message {
+                        HostToAssistant::SendUsart(data) => {
+                            target_tx.send_raw(data)
+                        }
+                    }
+                })
+                .expect("Error processing host request");
+            host_rx.clear_buf();
+
+            // We need this critical section to protect against a race
+            // conditions with the interrupt handlers. Otherwise, the following
+            // sequence of events could occur:
+            // 1. We check the queues here, they're empty.
+            // 2. New data is received, an interrupt handler adds it to a queue.
+            // 3. The interrupt handler is done, we're back here and going to
+            //    sleep.
+            //
+            // This might not be observable, if something else happens to wake
+            // us up before the test suite times out. But it could also lead to
+            // spurious test failures.
+            interrupt::free(|_| {
+                if !host_rx.can_process() && !target_rx.can_process() {
+                    asm::wfi();
+                }
+            });
+        }
+    }
+
+    #[task(binds = USART0, resources = [host_rx_int])]
+    fn usart0(cx: usart0::Context) {
+        cx.resources.host_rx_int.receive()
+            .expect("Error receiving from USART0");
+    }
+
+    #[task(binds = USART1, resources = [target_rx_int])]
+    fn usart1(cx: usart1::Context) {
+        cx.resources.target_rx_int.receive()
+            .expect("Error receiving from USART1");
+    }
+};

--- a/test-suite/src/assistant.rs
+++ b/test-suite/src/assistant.rs
@@ -1,0 +1,67 @@
+use std::time::{
+    Duration,
+    Instant,
+};
+
+use host_lib::conn::{
+    Conn,
+    ConnReceiveError,
+    ConnSendError,
+};
+use lpc845_messages::{
+    HostToAssistant,
+    AssistantToHost,
+};
+
+
+/// The connection to the test assistant
+pub struct Assistant<'r>(pub(crate) &'r mut Conn);
+
+impl<'r> Assistant<'r> {
+    /// Instruct assistant to send this message to the target via USART
+    pub fn send_to_target_usart(&mut self, message: &[u8])
+        -> Result<(), AssistantUsartSendError>
+    {
+        self.0.send(&HostToAssistant::SendUsart(message))
+            .map_err(|err| AssistantUsartSendError(err))
+    }
+
+    /// Wait to receive the provided data via USART
+    ///
+    /// Returns the receive buffer, once the data was received. Returns an
+    /// error, if it times out before that, or an I/O error occurs.
+    pub fn receive_from_target_usart(&mut self, data: &[u8], timeout: Duration)
+        -> Result<Vec<u8>, AssistantUsartWaitError>
+    {
+        let mut buf   = Vec::new();
+        let     start = Instant::now();
+
+        loop {
+            if buf.windows(data.len()).any(|window| window == data) {
+                return Ok(buf);
+            }
+            if start.elapsed() > timeout {
+                return Err(AssistantUsartWaitError::Timeout);
+            }
+
+            let mut tmp = Vec::new();
+            let event = self.0.receive::<AssistantToHost>(timeout, &mut tmp)
+                .map_err(|err| AssistantUsartWaitError::Receive(err))?;
+
+            match event {
+                AssistantToHost::UsartReceive(data) => buf.extend(data),
+            }
+        }
+    }
+}
+
+
+#[derive(Debug)]
+pub struct AssistantUsartSendError(ConnSendError);
+
+#[derive(Debug)]
+pub enum AssistantUsartWaitError {
+    Receive(ConnReceiveError),
+    Timeout,
+}
+

--- a/test-suite/src/error.rs
+++ b/test-suite/src/error.rs
@@ -11,6 +11,7 @@ use super::{
         TargetUsartSendError,
         TargetUsartWaitError,
     },
+    test_stand::NotConfiguredError,
 };
 
 
@@ -21,11 +22,18 @@ pub type Result<T = ()> = std::result::Result<T, Error>;
 /// Error type specific to this test suite
 #[derive(Debug)]
 pub enum Error {
+    NotConfigured(NotConfiguredError),
     SerialSend(SerialSendError),
     SerialWait(SerialWaitError),
     TargetUsartSend(TargetUsartSendError),
     TargetUsartWait(TargetUsartWaitError),
     TestStandInit(TestStandInitError),
+}
+
+impl From<NotConfiguredError> for Error {
+    fn from(err: NotConfiguredError) -> Self {
+        Self::NotConfigured(err)
+    }
 }
 
 impl From<SerialSendError> for Error {

--- a/test-suite/src/error.rs
+++ b/test-suite/src/error.rs
@@ -7,6 +7,10 @@ use host_lib::{
 };
 
 use super::{
+    assistant::{
+        AssistantUsartSendError,
+        AssistantUsartWaitError,
+    },
     target::{
         TargetUsartSendError,
         TargetUsartWaitError,
@@ -22,12 +26,26 @@ pub type Result<T = ()> = std::result::Result<T, Error>;
 /// Error type specific to this test suite
 #[derive(Debug)]
 pub enum Error {
+    AssistantUsartSend(AssistantUsartSendError),
+    AssistantUsartWait(AssistantUsartWaitError),
     NotConfigured(NotConfiguredError),
     SerialSend(SerialSendError),
     SerialWait(SerialWaitError),
     TargetUsartSend(TargetUsartSendError),
     TargetUsartWait(TargetUsartWaitError),
     TestStandInit(TestStandInitError),
+}
+
+impl From<AssistantUsartSendError> for Error {
+    fn from(err: AssistantUsartSendError) -> Self {
+        Self::AssistantUsartSend(err)
+    }
+}
+
+impl From<AssistantUsartWaitError> for Error {
+    fn from(err: AssistantUsartWaitError) -> Self {
+        Self::AssistantUsartWait(err)
+    }
 }
 
 impl From<NotConfiguredError> for Error {

--- a/test-suite/src/lib.rs
+++ b/test-suite/src/lib.rs
@@ -5,6 +5,7 @@
 //! a generally usable library that can be shared with other test suites.
 
 
+pub mod assistant;
 pub mod error;
 pub mod target;
 pub mod test_stand;

--- a/test-suite/src/target.rs
+++ b/test-suite/src/target.rs
@@ -16,13 +16,9 @@ use host_lib::conn::{
 
 
 /// Test-suite-specific wrapper around `host_lib::Target`
-pub struct Target<'r>(&'r mut Conn);
+pub struct Target<'r>(pub(crate) &'r mut Conn);
 
 impl<'r> Target<'r> {
-    pub(crate) fn new(target: &'r mut Conn) -> Self {
-        Self(target)
-    }
-
     /// Instruct the target to send this message via USART
     pub fn send_usart(&mut self, message: &[u8])
         -> Result<(), TargetUsartSendError>

--- a/test-suite/src/target.rs
+++ b/test-suite/src/target.rs
@@ -15,7 +15,7 @@ use host_lib::conn::{
 };
 
 
-/// Test-suite-specific wrapper around `host_lib::Target`
+/// The connection to the test target
 pub struct Target<'r>(pub(crate) &'r mut Conn);
 
 impl<'r> Target<'r> {

--- a/test-suite/src/test_stand.rs
+++ b/test-suite/src/test_stand.rs
@@ -3,7 +3,10 @@ use host_lib::{
     test_stand::TestStandInitError,
 };
 
-use super::target::Target;
+use super::{
+    assistant::Assistant,
+    target::Target,
+};
 
 
 /// An instance of the test stand
@@ -26,6 +29,14 @@ impl TestStand {
         match &mut self.0.target {
             Some(target) => Ok(Target(target)),
             None         => Err(NotConfiguredError("target")),
+        }
+    }
+
+    /// Returns the connection to the test assistant
+    pub fn assistant(&mut self) -> Result<Assistant, NotConfiguredError> {
+        match &mut self.0.assistant {
+            Some(assistant) => Ok(Assistant(assistant)),
+            None            => Err(NotConfiguredError("assistant")),
         }
     }
 

--- a/test-suite/src/test_stand.rs
+++ b/test-suite/src/test_stand.rs
@@ -24,7 +24,7 @@ impl TestStand {
     /// Returns the connection to the test target (device under test)
     pub fn target(&mut self) -> Result<Target, NotConfiguredError> {
         match &mut self.0.target {
-            Some(target) => Ok(Target::new(target)),
+            Some(target) => Ok(Target(target)),
             None         => Err(NotConfiguredError("target")),
         }
     }

--- a/test-suite/src/test_stand.rs
+++ b/test-suite/src/test_stand.rs
@@ -22,12 +22,22 @@ impl TestStand {
     }
 
     /// Returns the connection to the test target (device under test)
-    pub fn target(&mut self) -> Target {
-        Target::new(&mut self.0.target)
+    pub fn target(&mut self) -> Result<Target, NotConfiguredError> {
+        match &mut self.0.target {
+            Some(target) => Ok(Target::new(target)),
+            None         => Err(NotConfiguredError("target")),
+        }
     }
 
     /// Returns the connection to the Serial-to-USB converter
-    pub fn serial(&mut self) -> &mut Serial {
-        &mut self.0.serial
+    pub fn serial(&mut self) -> Result<&mut Serial, NotConfiguredError> {
+        match &mut self.0.serial {
+            Some(serial) => Ok(serial),
+            None         => Err(NotConfiguredError("serial")),
+        }
     }
 }
+
+
+#[derive(Debug)]
+pub struct NotConfiguredError(&'static str);

--- a/test-suite/test-stand.toml
+++ b/test-suite/test-stand.toml
@@ -6,7 +6,7 @@
 target = "/dev/ttyACM0"
 
 # Serial connection to the test assistant
-#assistant = "/dev/ttyACM1"
+assistant = "/dev/ttyACM1"
 
 # Serial connection to the Serial-to-USB converter connected to the target
-serial = "/dev/ttyUSB0"
+#serial = "/dev/ttyUSB0"

--- a/test-suite/test-stand.toml
+++ b/test-suite/test-stand.toml
@@ -5,5 +5,8 @@
 # Serial connection to the test target (device under test)
 target = "/dev/ttyACM0"
 
+# Serial connection to the test assistant
+#assistant = "/dev/ttyACM1"
+
 # Serial connection to the Serial-to-USB converter connected to the target
 serial = "/dev/ttyUSB0"

--- a/test-suite/tests/usart.rs
+++ b/test-suite/tests/usart.rs
@@ -27,10 +27,10 @@ fn it_should_send_messages() -> Result {
     let mut test_stand = TestStand::new()?;
 
     let message = b"Hello, world!";
-    test_stand.target().send_usart(message)?;
+    test_stand.target()?.send_usart(message)?;
 
     let timeout  = Duration::from_millis(50);
-    let received = test_stand.serial().wait_for(message, timeout)?;
+    let received = test_stand.serial()?.wait_for(message, timeout)?;
 
     assert_eq!(received, message);
     Ok(())
@@ -41,10 +41,10 @@ fn it_should_receive_messages() -> Result {
     let mut test_stand = TestStand::new()?;
 
     let message = b"Hello, world!";
-    test_stand.serial().send(message)?;
+    test_stand.serial()?.send(message)?;
 
     let timeout  = Duration::from_millis(50);
-    let received = test_stand.target().wait_for_usart_rx(message, timeout)?;
+    let received = test_stand.target()?.wait_for_usart_rx(message, timeout)?;
 
     assert_eq!(received, message);
     Ok(())

--- a/test-suite/tests/usart.rs
+++ b/test-suite/tests/usart.rs
@@ -2,16 +2,15 @@
 //!
 //! This test suite requires two serial connections:
 //! - To the test target, to control the device's behavior.
-//! - To the target's USART instance used for the test, via a USB/Serial
-//!   converter.
+//! - To the test assistant, to send/receive message to/from the target's USART.
 //!
 //! The configuration file (`test-stand.toml`) is used to determine which serial
 //! ports to connect to for each purpose. You probably need to update it, to
 //! reflect the realities on your system.
 //!
-//! As of this writing, the USART being used for this test expects to receive
-//! on PIO0_26 (pin 12 on the LPC845-BRK) and send on PIO0_27 (pin 13). Please
-//! connect your USB/Serial converter accordingly.
+//! As of this writing, both the target and the assistant use PIO0_26 (pin 12 on
+//! the LPC845-BRK) for receiving and PIO0_27 (pin 13) for sending. Please
+//! connect the target and assistant accordingly.
 
 
 use std::time::Duration;
@@ -30,7 +29,8 @@ fn it_should_send_messages() -> Result {
     test_stand.target()?.send_usart(message)?;
 
     let timeout  = Duration::from_millis(50);
-    let received = test_stand.serial()?.wait_for(message, timeout)?;
+    let received = test_stand.assistant()?
+        .receive_from_target_usart(message, timeout)?;
 
     assert_eq!(received, message);
     Ok(())
@@ -41,7 +41,7 @@ fn it_should_receive_messages() -> Result {
     let mut test_stand = TestStand::new()?;
 
     let message = b"Hello, world!";
-    test_stand.serial()?.send(message)?;
+    test_stand.assistant()?.send_to_target_usart(message)?;
 
     let timeout  = Duration::from_millis(50);
     let received = test_stand.target()?.wait_for_usart_rx(message, timeout)?;


### PR DESCRIPTION
This isn't strictly necessary, but a test assistant board will be needed anyway, to test things like GPIO. I figured porting the existing tests is a good first step towards making that happen. And having too much external hardware for the various tests (i.e. test assistant for GPIO and USB/serial converter for USART) would be too cumbersome, so using the assistant board for everything is the way to go, in my opinion.