### PR TITLE
Make fields with error causes public

### DIFF
--- a/host-lib/src/config.rs
+++ b/host-lib/src/config.rs
@@ -36,4 +36,4 @@ impl Config {
 
 
 #[derive(Debug)]
-pub struct ConfigReadError(Error);
+pub struct ConfigReadError(pub Error);

--- a/host-lib/src/conn.rs
+++ b/host-lib/src/conn.rs
@@ -106,15 +106,15 @@ impl Conn {
 
 
 #[derive(Debug)]
-pub struct ConnInitError(serialport::Error);
+pub struct ConnInitError(pub serialport::Error);
 
 
 #[derive(Debug)]
-pub struct ConnSendError(Error);
+pub struct ConnSendError(pub Error);
 
 
 #[derive(Debug)]
-pub struct ConnReceiveError(Error);
+pub struct ConnReceiveError(pub Error);
 
 impl ConnReceiveError {
     pub fn is_timeout(&self) -> bool {

--- a/host-lib/src/serial.rs
+++ b/host-lib/src/serial.rs
@@ -91,10 +91,11 @@ impl Serial {
 
 
 #[derive(Debug)]
-pub struct SerialInitError(serialport::Error);
+pub struct SerialInitError(pub serialport::Error);
 
 #[derive(Debug)]
-pub struct SerialSendError(io::Error);
+pub struct SerialSendError(pub io::Error);
+
 
 #[derive(Debug)]
-pub struct SerialWaitError(Error);
+pub struct SerialWaitError(pub Error);


### PR DESCRIPTION
This might come in handy, if the caller wants to do some more specific
error handling.