### PR TITLE
Migrate from RTFM to RTIC

### DIFF
--- a/test-assistant/Cargo.toml
+++ b/test-assistant/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 
 [dependencies]
-cortex-m-rtfm     = "0.5.1"
+cortex-m-rtic     = "0.5.3"
 heapless          = "0.5.4"
 panic-semihosting = "0.5.3"
 

--- a/test-assistant/src/main.rs
+++ b/test-assistant/src/main.rs
@@ -67,7 +67,7 @@ use lpc845_messages::{
 };
 
 
-#[rtfm::app(device = lpc8xx_hal::pac)]
+#[rtic::app(device = lpc8xx_hal::pac)]
 const APP: () = {
     struct Resources {
         host_rx_int:  RxInt<'static, USART0>,

--- a/test-target/Cargo.toml
+++ b/test-target/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 
 [dependencies]
-cortex-m-rtfm     = "0.5.1"
+cortex-m-rtic     = "0.5.3"
 heapless          = "0.5.4"
 panic-semihosting = "0.5.3"
 

--- a/test-target/src/main.rs
+++ b/test-target/src/main.rs
@@ -61,7 +61,7 @@ use lpc845_messages::{
 };
 
 
-#[rtfm::app(device = lpc8xx_hal::pac)]
+#[rtic::app(device = lpc8xx_hal::pac)]
 const APP: () = {
     struct Resources {
         host_rx_int:  RxInt<'static, USART0>,


### PR DESCRIPTION
The framework has simply been renamed, so nothing should actually
change.