### PR TITLE
Switch to `cargo-embed` as default tool for flashing the device

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,12 +73,13 @@ Target Pin | Assistant Pin | Note
 
 ### Software Setup
 
-Besides a Rust toolchain, you need OpenOCD and [arm-none-eabi-gdb] installed on your workstation, to download the firmware. The latest official release of OpenOCD won't do, unfortunately. Use a recent version from Git, or the [xPack binaries].
+Besides a Rust toolchain, you need `cargo-embed` to download the firmware: `cargo install cargo-embed`
 
-In addition, you need to update some configuration, to reflect the realities on your system:
+Since the setup uses two identical LPC845-BRK boards, `cargo-embed` needs some way to distinguish between them. For this reason, the configuration files (`test-target/Embed.toml` and `test-assisant/Embed.toml`) specify serial number in the `probe_selector` configuration.
 
-1. Update `test-target/dap-serial.cfg` and `test-assistant/dap-serial.cfg`, as described in those files. Otherwise OpenOCD/GDB won't be able to distinguish the two LPC845-BRK boards, and might try to upload both firmwares to the same device.
-1. Update `test-suite/test-stand.toml` to make sure the test suite has the correct paths to the serial device files. Otherwise, it won't be able to communicate with the firmwares.
+Either update the serial number there, or override `probe_selector` in an `Embed.local.toml`. On Linux, you can figure out the serial number of your device like this: `udevadm info /path/to/device`
+
+Watch out for `ID_SERIAL_SHORT` in the output.
 
 ### Running
 
@@ -86,14 +87,14 @@ Once you have all of this set up, you can download the test target firmware like
 
 ```
 cd test-target
-cargo run
+cargo embed
 ```
 
 And the test assistant firmware like this:
 
 ```
 cd test-assistant
-cargo run
+cargo embed
 ```
 
 Once the firmware is running on the device, you can execute the test suite:

--- a/firmware-lib/Cargo.toml
+++ b/firmware-lib/Cargo.toml
@@ -12,6 +12,7 @@ postcard = "0.5.0"
 
 [dependencies.lpc8xx-hal]
 git      = "https://github.com/lpc-rs/lpc8xx-hal.git"
+rev      = "f8d837ecf8d086d294e96efe45bd47fe12da8f39"
 features = ["845"]
 
 [dependencies.serde]

--- a/test-assistant/Cargo.toml
+++ b/test-assistant/Cargo.toml
@@ -20,6 +20,7 @@ path     = "../firmware-lib"
 
 [dependencies.lpc8xx-hal]
 git      = "https://github.com/lpc-rs/lpc8xx-hal.git"
+rev      = "f8d837ecf8d086d294e96efe45bd47fe12da8f39"
 features = ["845m301jbd48", "845-rt"]
 
 [dependencies.void]

--- a/test-assistant/Embed.toml
+++ b/test-assistant/Embed.toml
@@ -1,4 +1,6 @@
 [probe]
+# The item behind the last ":" is the serial number of the device. You need to
+# update this. See README.md for more information.
 probe_selector = "1fc9:0132:0F01D03A"
 
 [general]

--- a/test-assistant/Embed.toml
+++ b/test-assistant/Embed.toml
@@ -1,0 +1,5 @@
+[probe]
+probe_selector = "1fc9:0132:0F01D03A"
+
+[general]
+chip = "LPC845M301JHI48"

--- a/test-target/Cargo.toml
+++ b/test-target/Cargo.toml
@@ -20,6 +20,7 @@ path     = "../firmware-lib"
 
 [dependencies.lpc8xx-hal]
 git      = "https://github.com/lpc-rs/lpc8xx-hal.git"
+rev      = "f8d837ecf8d086d294e96efe45bd47fe12da8f39"
 features = ["845m301jbd48", "845-rt"]
 
 [dependencies.void]

--- a/test-target/Embed.toml
+++ b/test-target/Embed.toml
@@ -1,0 +1,5 @@
+[probe]
+probe_selector = "1fc9:0132:11020031"
+
+[general]
+chip = "LPC845M301JHI48"

--- a/test-target/Embed.toml
+++ b/test-target/Embed.toml
@@ -1,4 +1,6 @@
 [probe]
+# The item behind the last ":" is the serial number of the device. You need to
+# update this. See README.md for more information.
 probe_selector = "1fc9:0132:11020031"
 
 [general]


### PR DESCRIPTION
OpenOCD has been a constant low-level annoyance for me since I learned of its existence. Today I've run into weird problems yet again (seems like it tries flashing the target board instead the assistant board, ignoring the serial number in the configuration).

Since `cargo-embed` exists now, there's really no reason to try and get this to work. I've left the OpenOCD configuration in the repository for now, but updated the documentation to explain `cargo-embed` instead.